### PR TITLE
docs: add Llama Stack setup instructions for local models

### DIFF
--- a/examples/cc_vec_complete_rag_workflow.py
+++ b/examples/cc_vec_complete_rag_workflow.py
@@ -10,6 +10,11 @@ This comprehensive example shows:
 6. Cleanup
 
 Run with: uv run python examples/complete_rag_workflow.py
+
+Optional environment variables for alternative endpoints:
+    - OPENAI_BASE_URL: Custom endpoint (e.g., http://localhost:11434/v1)
+    - OPENAI_VERIFY_SSL: Set to "false" for self-signed certs (dev only)
+    - OPENAI_EMBEDDING_MODEL: Custom model (e.g., nomic-embed-text)
 """
 
 import os

--- a/examples/cc_vec_rag_example.py
+++ b/examples/cc_vec_rag_example.py
@@ -10,6 +10,11 @@ Requirements:
     - OPENAI_API_KEY environment variable
     - ATHENA_OUTPUT_BUCKET environment variable
     - AWS credentials configured
+
+Optional (for alternative endpoints):
+    - OPENAI_BASE_URL: Custom OpenAI-compatible endpoint (e.g., http://localhost:11434/v1 for Ollama)
+    - OPENAI_VERIFY_SSL: Set to "false" to disable SSL verification for self-signed certs (dev only)
+    - OPENAI_EMBEDDING_MODEL: Custom embedding model (e.g., nomic-embed-text for Ollama)
 """
 
 import os
@@ -20,6 +25,9 @@ from openai import OpenAI
 
 def main():
     # Initialize OpenAI client
+    # Note: If using alternative endpoints with self-signed certs, set:
+    #   export OPENAI_BASE_URL=https://localhost:8443/v1
+    #   export OPENAI_VERIFY_SSL=false
     client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
     # Step 1: Index Common Crawl content into a vector store

--- a/src/cc_vec/cli/main.py
+++ b/src/cc_vec/cli/main.py
@@ -651,11 +651,17 @@ def index(ctx, vector_store_name, limit, chunk_size, overlap, output, **filter_k
 
             click.echo(f"Auto-generated vector store name: {vector_store_name}")
 
+        # Load config to get embedding model settings from environment
+        config = load_config()
+
         # Construct VectorStoreConfig
         vector_store_config = VectorStoreConfig(
             name=vector_store_name,
             chunk_size=chunk_size,
             overlap=overlap,
+            embedding_model=config.openai.embedding_model
+            or "text-embedding-3-small",
+            embedding_dimensions=config.openai.embedding_dimensions or 1536,
         )
 
         # Use the simplified API that handles all client initialization

--- a/src/cc_vec/mcp/handlers/cc_index.py
+++ b/src/cc_vec/mcp/handlers/cc_index.py
@@ -46,11 +46,19 @@ class CCIndexHandler(FilterHandler):
             else:
                 vector_store_name = f"ccvec_{timestamp}"
 
+        # Load config to get embedding model settings from environment
+        from ...types.config import load_config
+
+        config = load_config()
+
         # Construct VectorStoreConfig
         vector_store_config = VectorStoreConfig(
             name=vector_store_name,
             chunk_size=chunk_size,
             overlap=overlap,
+            embedding_model=config.openai.embedding_model
+            or "text-embedding-3-small",
+            embedding_dimensions=config.openai.embedding_dimensions or 1536,
         )
 
         try:


### PR DESCRIPTION
Add documentation and configuration for running cc-vec with local models via Ollama + Llama Stack, providing a fully local alternative to OpenAI for vector operations.

Documentation:
- 4-step setup guide: Ollama, ChromaDB (optional), Llama Stack, cc-vec
- Commands for starter distribution with OLLAMA_URL and CHROMADB_URL
- Environment variables for local model configuration
- Links to Llama Stack, Ollama, and ChromaDB documentation

Configuration:
- CLI and MCP handlers now use OPENAI_EMBEDDING_MODEL and OPENAI_EMBEDDING_DIMENSIONS from environment when set
- Examples updated with alternative endpoint documentation

Note: AWS credentials are still required for Common Crawl/Athena queries.